### PR TITLE
Add file reading and writing capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,23 @@
 # Maven Test Runner MCP Server
 
-An MCP (Model Context Protocol) server that allows Claude Desktop to run Maven tests and get concise, actionable test results. Perfect for verifying code refactoring without getting overwhelmed by verbose Maven output.
+An MCP (Model Context Protocol) server that allows Claude Desktop to run Maven tests, read source files, and make code changes. Perfect for verifying refactoring and editing code directly from Claude Desktop.
 
 ## Features
 
+### Testing
 - **Concise Test Reports**: Get clear ✅/❌ results without Maven's verbose output
 - **Smart Error Detection**: Automatically identifies compilation issues, dependency problems, and test failures
 - **Helpful Hints**: Suggests fixes for common issues (missing `-am` flag, Jackson errors, etc.)
 - **Flexible Testing**: Run all tests in a module or target specific test classes
+
+### File Operations
+- **Read Source Files**: View any file in your workspace (Kotlin, Java, XML, etc.)
+- **Edit Files**: Modify source code directly from Claude Desktop
+- **Path Flexibility**: Support for both absolute and workspace-relative paths
+
+### General
 - **Workspace Awareness**: Configurable workspace directory with tilde expansion support
+- **Safe Operations**: Read files before writing, with clear error messages
 
 ## Prerequisites
 
@@ -87,12 +96,41 @@ Run the LagreMedlemsperiodeMedlTest tests in the saksflyt module
 I just refactored the Medlemsperiode class. Can you run the tests to make sure everything still works?
 ```
 
+**Read and edit files:**
+```
+Show me the Behandling.kt file in the domain module
+```
+```
+Update the Behandling class to add a new method for validation
+```
+
 ### Tool Interface
 
-The server provides a `run_tests` tool with these parameters:
+The server provides three tools:
 
+#### 1. `run_tests`
+Run Maven tests for a specific module.
+
+Parameters:
 - `project` (required): Maven module name (e.g., "saksflyt", "domain", "common")
 - `testClass` (optional): Specific test class to run (e.g., "LagreMedlemsperiodeMedlTest")
+
+#### 2. `read_file`
+Read the contents of a source file.
+
+Parameters:
+- `filePath` (required): Path to file (absolute or relative to workspace)
+  - Example: `domain/src/main/kotlin/no/nav/melosys/domain/Behandling.kt`
+  - Example: `~/source/nav/melosys-api/domain/src/main/kotlin/no/nav/melosys/domain/Behandling.kt`
+
+#### 3. `write_file`
+Write or update a source file.
+
+⚠️ **Warning**: This overwrites the entire file. Always read the file first!
+
+Parameters:
+- `filePath` (required): Path to file (absolute or relative to workspace)
+- `content` (required): Complete new file content
 
 ## Output Examples
 
@@ -118,6 +156,31 @@ testOppdaterMedlemsperiode: NullPointerException at line 45
 ```
 ⚠️  No tests were run. Check your test configuration.
 ```
+
+## Typical Workflow
+
+Here's a common workflow using all three tools:
+
+1. **Read existing code**:
+   ```
+   Show me the Behandling.kt file
+   ```
+
+2. **Make changes**:
+   ```
+   Add a validation method that checks if the status is valid
+   ```
+   (Claude will read the file, understand it, and write the updated version)
+
+3. **Verify changes**:
+   ```
+   Run the domain tests to make sure my changes work
+   ```
+
+4. **Fix issues if needed**:
+   ```
+   The test failed - can you fix the validation logic?
+   ```
 
 ## How It Works
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   Tool,
 } from "@modelcontextprotocol/sdk/types.js";
 import { spawn } from "child_process";
+import { readFile, writeFile } from "fs/promises";
 import { homedir } from "os";
 import { resolve } from "path";
 
@@ -197,7 +198,20 @@ async function runTests(project: string, testClass?: string): Promise<TestResult
   });
 }
 
-// Define the tool
+// Read file function
+async function readFileContent(filePath: string): Promise<string> {
+  const absolutePath = resolve(expandPath(filePath));
+  const content = await readFile(absolutePath, "utf-8");
+  return content;
+}
+
+// Write file function
+async function writeFileContent(filePath: string, content: string): Promise<void> {
+  const absolutePath = resolve(expandPath(filePath));
+  await writeFile(absolutePath, content, "utf-8");
+}
+
+// Define the tools
 const RUN_TESTS_TOOL: Tool = {
   name: "run_tests",
   description: `Run Maven tests for a specific project module using the test wrapper script.
@@ -232,6 +246,67 @@ Workspace: ${WORKSPACE_DIR}`,
   },
 };
 
+const READ_FILE_TOOL: Tool = {
+  name: "read_file",
+  description: `Read the contents of a file in the workspace.
+
+This tool allows you to view source code files before making changes.
+Supports both absolute paths and paths relative to the workspace directory.
+
+Parameters:
+- filePath: Path to the file (e.g., "domain/src/main/kotlin/no/nav/melosys/domain/Behandling.kt" or absolute path)
+
+Use this tool to:
+- Examine code before refactoring
+- Review class implementations
+- Understand existing code structure
+
+Workspace: ${WORKSPACE_DIR}`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      filePath: {
+        type: "string",
+        description: "Path to the file to read (relative to workspace or absolute)",
+      },
+    },
+    required: ["filePath"],
+  },
+};
+
+const WRITE_FILE_TOOL: Tool = {
+  name: "write_file",
+  description: `Write or update a file in the workspace.
+
+This tool allows you to modify source code files.
+⚠️  WARNING: This overwrites the entire file content. Use with caution.
+
+Parameters:
+- filePath: Path to the file (relative to workspace or absolute)
+- content: The complete new content of the file
+
+Best practices:
+- Always read the file first to understand its current content
+- Preserve existing code structure and formatting
+- Test changes by running tests after modifications
+
+Workspace: ${WORKSPACE_DIR}`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      filePath: {
+        type: "string",
+        description: "Path to the file to write (relative to workspace or absolute)",
+      },
+      content: {
+        type: "string",
+        description: "The complete new content to write to the file",
+      },
+    },
+    required: ["filePath", "content"],
+  },
+};
+
 // Create and configure the server
 const server = new Server(
   {
@@ -248,7 +323,7 @@ const server = new Server(
 // List available tools
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   return {
-    tools: [RUN_TESTS_TOOL],
+    tools: [RUN_TESTS_TOOL, READ_FILE_TOOL, WRITE_FILE_TOOL],
   };
 });
 
@@ -287,6 +362,105 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         message += `\n\n💡 Make the script executable: chmod +x ${SCRIPT_PATH}`;
       } else if (errorMessage.includes("timeout")) {
         message += "\n\n💡 Tests took too long (>5 minutes). Consider running fewer tests.";
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: message,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  if (request.params.name === "read_file") {
+    const { filePath } = request.params.arguments as {
+      filePath: string;
+    };
+
+    if (!filePath) {
+      throw new Error("filePath parameter is required");
+    }
+
+    try {
+      // Handle both absolute and relative paths
+      const fullPath = filePath.startsWith("/") || filePath.startsWith("~")
+        ? filePath
+        : resolve(WORKSPACE_DIR, filePath);
+
+      const content = await readFileContent(fullPath);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: content,
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      let message = `❌ Error reading file: ${errorMessage}`;
+
+      if (errorMessage.includes("ENOENT")) {
+        message += `\n\n💡 File not found. Check the path is correct.`;
+      } else if (errorMessage.includes("EACCES")) {
+        message += `\n\n💡 Permission denied. Check file permissions.`;
+      }
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: message,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  if (request.params.name === "write_file") {
+    const { filePath, content } = request.params.arguments as {
+      filePath: string;
+      content: string;
+    };
+
+    if (!filePath) {
+      throw new Error("filePath parameter is required");
+    }
+
+    if (content === undefined) {
+      throw new Error("content parameter is required");
+    }
+
+    try {
+      // Handle both absolute and relative paths
+      const fullPath = filePath.startsWith("/") || filePath.startsWith("~")
+        ? filePath
+        : resolve(WORKSPACE_DIR, filePath);
+
+      await writeFileContent(fullPath, content);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `✅ File written successfully: ${filePath}`,
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      let message = `❌ Error writing file: ${errorMessage}`;
+
+      if (errorMessage.includes("ENOENT")) {
+        message += `\n\n💡 Directory doesn't exist. Create the directory first.`;
+      } else if (errorMessage.includes("EACCES")) {
+        message += `\n\n💡 Permission denied. Check file/directory permissions.`;
       }
 
       return {


### PR DESCRIPTION
Extends the MCP server with tools to read and edit source files directly from Claude Desktop.

New tools:
- read_file: View any file in the workspace (supports absolute and relative paths)
- write_file: Modify source code files with full content replacement

Features:
- Path resolution handles both absolute paths and workspace-relative paths
- Tilde expansion support for home directory shortcuts
- Comprehensive error handling with helpful hints
- Safety warnings about file overwriting in tool descriptions

Use cases:
- Read source code before refactoring
- Make code changes and verify with tests
- Edit configuration files
- Update documentation

Updated README with:
- New tools documentation
- Usage examples for file operations
- Typical workflow example showing read → edit → test cycle
- Updated feature list

This enables a complete development workflow: read code, make changes, run tests, and iterate - all from Claude Desktop.