### PR TITLE
Remove project-specific references and make examples generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add this configuration:
       "command": "node",
       "args": ["/absolute/path/to/mcp-maven-test-runner/build/index.js"],
       "env": {
-        "WORKSPACE_DIR": "/Users/username/source/nav/melosys-api",
+        "WORKSPACE_DIR": "/Users/username/projects/my-maven-project",
         "PATH": "/Users/username/.sdkman/candidates/maven/current/bin:/Users/username/.sdkman/candidates/java/current/bin:/usr/local/bin:/usr/bin:/bin"
       }
     }
@@ -74,25 +74,25 @@ Once configured, Claude can run tests using natural language:
 
 **Run all tests in a module:**
 ```
-Run all tests in the saksflyt module
+Run all tests in the domain module
 ```
 
 **Run a specific test class:**
 ```
-Run the LagreMedlemsperiodeMedlTest tests in the saksflyt module
+Run the UserServiceTest tests in the service module
 ```
 
 **Verify refactoring:**
 ```
-I just refactored the Medlemsperiode class. Can you run the tests to make sure everything still works?
+I just refactored the UserService class. Can you run the tests to make sure everything still works?
 ```
 
 ### Tool Interface
 
 The server provides a `run_tests` tool with these parameters:
 
-- `project` (required): Maven module name (e.g., "saksflyt", "domain", "common")
-- `testClass` (optional): Specific test class to run (e.g., "LagreMedlemsperiodeMedlTest")
+- `project` (required): Maven module name (e.g., "domain", "service", "common")
+- `testClass` (optional): Specific test class to run (e.g., "UserServiceTest")
 
 ## Output Examples
 
@@ -108,8 +108,8 @@ The server provides a `run_tests` tool with these parameters:
 Tests run: 5, Failures: 2, Errors: 0, Skipped: 0
 
 🔍 Failure details:
-testLagreMedlemsperiode: Expected <2023-01-01> but was <2023-01-02>
-testOppdaterMedlemsperiode: NullPointerException at line 45
+testCreateUser: Expected <2023-01-01> but was <2023-01-02>
+testUpdateUser: NullPointerException at line 45
 
 💡 Tip: Cross-module dependency issue. Try running with -am flag.
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ function expandPath(path: string): string {
 
 // Get workspace directory from environment or use default
 const WORKSPACE_DIR = expandPath(
-  process.env.WORKSPACE_DIR || "~/source/nav/melosys-api"
+  process.env.WORKSPACE_DIR || "~/projects/my-maven-project"
 );
 const SCRIPT_PATH = expandPath("~/.claude/scripts/run-tests.sh");
 
@@ -206,8 +206,8 @@ This tool executes tests in your Maven project and returns a concise summary.
 Perfect for verifying code refactoring or checking if specific tests pass.
 
 Parameters:
-- project: The Maven module name (e.g., "saksflyt", "common", "domain")
-- testClass: (optional) Specific test class to run (e.g., "LagreMedlemsperiodeMedlTest")
+- project: The Maven module name (e.g., "domain", "service", "common")
+- testClass: (optional) Specific test class to run (e.g., "UserServiceTest")
 
 The tool automatically handles:
 - Running tests in the correct workspace directory
@@ -221,11 +221,11 @@ Workspace: ${WORKSPACE_DIR}`,
     properties: {
       project: {
         type: "string",
-        description: "The Maven module/project name (e.g., 'saksflyt')",
+        description: "The Maven module/project name (e.g., 'domain', 'service')",
       },
       testClass: {
         type: "string",
-        description: "Optional: Specific test class to run (e.g., 'LagreMedlemsperiodeMedlTest')",
+        description: "Optional: Specific test class to run (e.g., 'UserServiceTest')",
       },
     },
     required: ["project"],


### PR DESCRIPTION
Makes the codebase more reusable for any Maven project by removing NAV/Melosys-specific references.

Changes:
- Update default WORKSPACE_DIR from ~/source/nav/melosys-api to ~/projects/my-maven-project
- Replace specific module names (saksflyt) with generic examples (domain, service)
- Replace specific test class names (LagreMedlemsperiodeMedlTest) with generic examples (UserServiceTest)
- Update test method examples (testLagreMedlemsperiode → testCreateUser)
- Update README configuration examples with generic paths
- Update tool descriptions with generic module and class names

All functionality remains identical - only example names and default paths have changed to be more universally applicable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)